### PR TITLE
fix: correct off-by-one in alphabet loop (issue #29)

### DIFF
--- a/include/pntr_nuklear.h
+++ b/include/pntr_nuklear.h
@@ -227,7 +227,7 @@ PNTR_NUKLEAR_API struct nk_context* pntr_load_nuklear(pntr_font* font) {
     #define PNTR_LOAD_NUKLEAR_ALPHABET_START (33)
     #define PNTR_LOAD_NUKLEAR_ALPHABET_LEN (172 - PNTR_LOAD_NUKLEAR_ALPHABET_START)
     char theAlphabet[PNTR_LOAD_NUKLEAR_ALPHABET_LEN];
-    for (int i = 0; i <= PNTR_LOAD_NUKLEAR_ALPHABET_LEN; i++) {
+    for (int i = 0; i < PNTR_LOAD_NUKLEAR_ALPHABET_LEN; i++) {
         theAlphabet[i] = (char)(i + PNTR_LOAD_NUKLEAR_ALPHABET_START);
     }
 


### PR DESCRIPTION
## Summary

- Changes `<=` to `<` in the `theAlphabet` loop in `pntr_load_nuklear`
- The array has `PNTR_LOAD_NUKLEAR_ALPHABET_LEN` elements (indices 0–138), but the old condition wrote to index 139 (one past the end), invoking undefined behavior
- Eliminates the `-Waggressive-loop-optimizations` compiler warning

Fixes #29

## Test plan

- [ ] Build with `-Waggressive-loop-optimizations` and confirm warning is gone
- [ ] Verify font rendering still works correctly in a demo

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)